### PR TITLE
Ability to require the tasks without the hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ set :yarn_roles, :all                                     # default
 set :yarn_env_variables, {}                               # default
 ```
 
+Alternatively, if you want to have control on the execution of yarn tasks
+
+```ruby
+# Capfile
+require capistrano/yarn/without_hooks
+```
+
+You can then add the hooks on a per deploy script basis
+
+```ruby
+# config/deploy/my_stage_with_npm.rb
+before 'deploy:updated', 'yarn:install'
+```
+
 ### Dependencies
 
 yarn allows for normal `dependencies` and `devDependencies`. By default this gem uses `'--production --silent --no-progress'` as the install flags which will **only** install `dependencies` and skip `devDependencies`. If you want your `devDependencies` installed as well, then remove `--production`.

--- a/lib/capistrano/hooks/yarn.rb
+++ b/lib/capistrano/hooks/yarn.rb
@@ -1,0 +1,1 @@
+before 'deploy:updated', 'yarn:install'

--- a/lib/capistrano/tasks/deploy_yarn.rake
+++ b/lib/capistrano/tasks/deploy_yarn.rake
@@ -1,0 +1,2 @@
+load File.expand_path('../yarn.rake', __FILE__)
+load File.expand_path('../../hooks/yarn.rb', __FILE__)

--- a/lib/capistrano/yarn/without_hooks.rb
+++ b/lib/capistrano/yarn/without_hooks.rb
@@ -1,0 +1,1 @@
+load File.expand_path('../../tasks/yarn.rake', __FILE__)


### PR DESCRIPTION
Inspired from Capistrano Passenger

Also, it is sad that this repo is a fork and not just a brand new repo. 
First, because it is definitely not the same thing,
Second because it can cause a mess whith forking and contributing : I have forked + made a similar PR on the original npm repo, and then I couldn't fork this one since I already have a fork of the npm repo this repo is based on.